### PR TITLE
Removing --upgrade parameter in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-parsedatetime --upgrade
-google-api-python-client --upgrade
-oauth2client --upgrade
-PyOpenSSL --upgrade
+parsedatetime
+google-api-python-client
+oauth2client
+PyOpenSSL


### PR DESCRIPTION
This parameter should usually be passed directly to `pip`.
Putting it here breaks `pip` usage:
```
$ pip install -U -r ga_page_view/requirements.txt
Usage: pip [options]

pip: error: no such option: --upgrade
```